### PR TITLE
Fix TCP flapping, filter unusable sensors, add missing battery data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,38 @@ a local TCP API on port `53970`.
 The integration:
 
 - connects to `IP:PORT` of the Felicity Wi-Fi module,
-- sends `wifilocalMonitor:get dev real infor`,
-- parses the JSON response,
+- sends `wifilocalMonitor:get dev real infor` (plus `get dev basice infor`,
+  `get dev set infor` and `get Date` for firmware/settings/signal data),
+- parses the JSON response(s),
 - creates **one device** in Home Assistant with multiple sensors:
-  - SOC, voltage, current, power
-  - temperatures
-  - max/min cell voltage and delta
-  - charge/discharge current limits
-  - state, fault, warning flags
+  - SOC, voltage, current, power (plus separate charge/discharge current
+    and power sensors)
+  - Battery Direction (charging/discharging/idle)
+  - Max/Min Cell Temperature
+  - Max/Min Cell Voltage and Cell Voltage Drift
+  - Pack/Cell voltages for up to 16 cells - automatically labeled and
+    scaled as either "Pack N Voltage" or "Cell N Voltage" depending on
+    what the connected battery actually reports (single- vs. multi-array
+    packs)
+  - Battery SOH, Battery Capacity (Ah)
+  - Charge/Discharge Voltage Limit, Max Charge/Discharge Current (runtime)
+  - Working Mode (official Felicity enum, e.g. Standby/Battery Mode/Fault/...)
+  - Battery Pack Count
+  - Battery BCU/SCU/BMU/LCD firmware versions, WiFi Module FW Version
+  - WiFi Module Signal (RSSI)
+  - Battery Type/SubType, Battery Serial, WiFi Module Serial
+  - Fault/Warning codes and settings-derived sensors (Cell Over/Under
+    Voltage, Cell Voltage @20%/@80%, Charge/Discharge Current Limit
+    from BMS protection settings)
+  - binary sensors: Battery Fault, Battery Warning, Battery Charging,
+    Battery Discharging, Battery Standby, Cell Voltage Drift High
 
-Tested with FLA48200 battery and Wi-Fi module listening on TCP port `53970`.
+Only sensors that actually return data for your specific battery/firmware
+are created - fields your device doesn't report are skipped automatically
+instead of showing up as permanently "unknown".
+
+Tested with **FLA48200** and **LUX-X-96050HG01** batteries, communicating
+with the Wi-Fi module (e.g. `IOTH2407`) on TCP port `53970`.
 
 ## Installation
 
@@ -31,6 +53,7 @@ Tested with FLA48200 battery and Wi-Fi module listening on TCP port `53970`.
          api.py
          config_flow.py
          sensor.py
+         binary_sensor.py
    ```
 
 2. Restart Home Assistant.
@@ -43,6 +66,11 @@ Tested with FLA48200 battery and Wi-Fi module listening on TCP port `53970`.
    - **Name** – any friendly name (e.g. `Felicity FLA48200`),
    - **Host** – IP of the Wi-Fi module (e.g. `192.168.1.68`),
    - **Port** – usually `53970`.
+   - **Model** *(optional)* – your battery's marketing model name (e.g.
+     `FLA48200`, `LUX-X-96050HG01`). The device only reports numeric
+     Type/SubType codes, not a human-readable model, so this can't be
+     detected automatically; leave it blank to fall back to a generic
+     label showing those codes instead.
 
 After that you should see one device with multiple sensors.
 

--- a/custom_components/felicity_battery/api.py
+++ b/custom_components/felicity_battery/api.py
@@ -69,7 +69,7 @@ class FelicityClient:
             set_text = set_raw.replace("'", '"').strip()
             merged: Dict[str, Any] = {}
 
-            # Разбираем несколько JSON-объектов подряд:
+            # Parse several consecutive JSON objects:
             depth = 0
             start = None
             json_objects: list[str] = []
@@ -86,7 +86,7 @@ class FelicityClient:
                             json_objects.append(set_text[start : i + 1])
                             start = None
 
-            # На всякий случай fallback на простое регулярное выражение
+            # Fallback to a simple regex, just in case
             if not json_objects:
                 json_objects = re.findall(r"\{.*?\}", set_text)
 

--- a/custom_components/felicity_battery/api.py
+++ b/custom_components/felicity_battery/api.py
@@ -8,6 +8,22 @@ from typing import Any, Dict
 
 _LOGGER = logging.getLogger(__name__)
 
+# --- Tuning knobs for the TCP dialog with the Felicity Wi-Fi module -------
+# The module answers some commands (e.g. "get dev set infor") with several
+# concatenated JSON objects sent across multiple TCP segments. The original
+# implementation stopped reading as soon as it saw the first "}", which
+# works for single-object replies but silently truncates multi-object
+# replies (dropping fields like wCVP80/wCVP20/cVolHi/cVolLo/bCCHi2/bDCHi2).
+# It also only waited 0.5s for the very first byte with no retry, which
+# made the whole update fail ("No data received from battery") whenever
+# the module was a few hundred ms slower than usual (e.g. busy talking to
+# the FSOLAR cloud at the same moment).
+CONNECT_TIMEOUT = 5.0
+FIRST_BYTE_TIMEOUT = 3.0
+IDLE_TIMEOUT = 0.4
+READ_RETRIES = 2
+READ_RETRY_BACKOFF = 0.5
+
 
 class FelicityApiError(Exception):
     """Error while communicating with Felicity battery."""
@@ -27,14 +43,16 @@ class FelicityClient:
         - wifilocalMonitor:get dev basice infor -> versions / type
         - wifilocalMonitor:get dev set infor    -> config / limits (multi-json)
         """
-        # 1. Runtime data
-        real_raw = await self._async_read_raw(b"wifilocalMonitor:get dev real infor")
+        # 1. Runtime data (critical - if this fails, the whole update fails)
+        real_raw = await self._async_read_raw_with_retry(
+            b"wifilocalMonitor:get dev real infor"
+        )
         real = self._parse_real_payload(real_raw)
         data: Dict[str, Any] = dict(real)
 
-        # 2. Basic info
+        # 2. Basic info (best effort)
         try:
-            basic_raw = await self._async_read_raw(
+            basic_raw = await self._async_read_raw_with_retry(
                 b"wifilocalMonitor:get dev basice infor"
             )
             basic_text = basic_raw.replace("'", '"').strip()
@@ -43,10 +61,9 @@ class FelicityClient:
         except Exception as err:
             _LOGGER.debug("Failed to read basic info: %s", err)
 
-        
-        # 3. Settings / limits (может быть в нескольких JSON-блоках)
+        # 3. Settings / limits (best effort, multiple JSON objects)
         try:
-            set_raw = await self._async_read_raw(
+            set_raw = await self._async_read_raw_with_retry(
                 b"wifilocalMonitor:get dev set infor"
             )
             set_text = set_raw.replace("'", '"').strip()
@@ -84,8 +101,9 @@ class FelicityClient:
             if merged:
                 data["_settings"] = merged
                 _LOGGER.debug(
-                    "Merged Felicity settings (%d keys): %s",
+                    "Merged Felicity settings (%d keys from %d objects): %s",
                     len(merged),
+                    len(json_objects),
                     merged,
                 )
             else:
@@ -94,38 +112,97 @@ class FelicityClient:
         except Exception as err:
             _LOGGER.debug("Failed to read settings info: %s", err)
 
+        # 4. Date/status info (best effort) - carries the Wi-Fi module's
+        # own signal strength (rssi), uptime (tick) and last reset reason
+        # (rstRS), none of which were queried before. One extra TCP
+        # round-trip per poll cycle (every DEFAULT_SCAN_INTERVAL seconds);
+        # if that ever becomes a problem for the module, this block can be
+        # removed without affecting anything else.
+        try:
+            date_raw = await self._async_read_raw_with_retry(
+                b"wifilocalMonitor:get Date"
+            )
+            date_text = date_raw.replace("'", '"').strip()
+            data["_date"] = json.loads(date_text)
+        except Exception as err:
+            _LOGGER.debug("Failed to read date/status info: %s", err)
+
         return data
 
+    async def _async_read_raw_with_retry(
+        self,
+        command: bytes,
+        retries: int = READ_RETRIES,
+        backoff: float = READ_RETRY_BACKOFF,
+    ) -> str:
+        """Retry _async_read_raw a couple of times before giving up.
+
+        The Wi-Fi module occasionally needs a bit longer to answer (e.g.
+        while it's also pushing data to the FSOLAR cloud). A single
+        transient failure here used to bubble straight up as UpdateFailed,
+        flipping every entity to 'unavailable' until the next 30s poll.
+        """
+        last_err: Exception | None = None
+        for attempt in range(retries + 1):
+            try:
+                return await self._async_read_raw(command)
+            except FelicityApiError as err:
+                last_err = err
+                _LOGGER.debug(
+                    "Attempt %d/%d for %r failed: %s",
+                    attempt + 1,
+                    retries + 1,
+                    command,
+                    err,
+                )
+                if attempt < retries:
+                    await asyncio.sleep(backoff)
+        assert last_err is not None
+        raise last_err
+
     async def _async_read_raw(self, command: bytes) -> str:
-        """Open TCP, send command, read response as text."""
+        """Open TCP, send command, read the *full* response as text.
+
+        Some replies (notably 'get dev set infor') consist of several
+        concatenated JSON objects and can arrive across multiple TCP
+        reads. We keep reading until the socket has been idle for
+        IDLE_TIMEOUT seconds instead of bailing out after the first
+        '}' we see, so multi-fragment replies aren't truncated.
+        """
         try:
-            reader, writer = await asyncio.open_connection(self._host, self._port)
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(self._host, self._port),
+                timeout=CONNECT_TIMEOUT,
+            )
         except Exception as err:
             raise FelicityApiError(
                 f"Error connecting to {self._host}:{self._port}: {err}"
             ) from err
 
+        data = b""
         try:
             writer.write(command)
             await writer.drain()
 
-            data = b""
-            for _ in range(20):
+            # Wait (generously) for the first byte of the response.
+            try:
+                data = await asyncio.wait_for(
+                    reader.read(4096), timeout=FIRST_BYTE_TIMEOUT
+                )
+            except asyncio.TimeoutError:
+                data = b""
+
+            # Keep draining the socket while data keeps trickling in.
+            while data:
                 try:
-                    chunk = await asyncio.wait_for(reader.read(1024), timeout=0.5)
+                    chunk = await asyncio.wait_for(
+                        reader.read(4096), timeout=IDLE_TIMEOUT
+                    )
                 except asyncio.TimeoutError:
                     break
                 if not chunk:
                     break
                 data += chunk
-                if b"}" in chunk:
-                    try:
-                        more = await asyncio.wait_for(reader.read(1024), timeout=0.2)
-                        if more:
-                            data += more
-                    except asyncio.TimeoutError:
-                        pass
-                    break
 
         except Exception as err:
             raise FelicityApiError(
@@ -251,15 +328,31 @@ class FelicityClient:
         if btemp is not None:
             result["BTemp"] = btemp
 
-        # BatcelList
-        m = re.search(r'"BatcelList"\s*:\s*\[\s*\[([0-9,\s-]+)\]', norm)
+        # BatcelList: [0] = pack/string voltages (~53V, confirmed against
+        # the FSOLAR app's "Batteriespannung" table), [1] = real individual
+        # cell voltages (~3.3V, confirmed against "Vol. der Zelle"). The
+        # second sub-array used to be dropped entirely - now captured too.
+        m = re.search(
+            r'"BatcelList"\s*:\s*\[\s*\[([0-9,\s-]+)\]\s*,\s*\[([0-9,\s-]+)\]\s*\]',
+            norm,
+        )
         if m:
-            cells_str = m.group(1)
             try:
-                cells = [int(x) for x in cells_str.split(",") if x.strip() != ""]
-                result["BatcelList"] = [cells]
+                cells0 = [int(x) for x in m.group(1).split(",") if x.strip() != ""]
+                cells1 = [int(x) for x in m.group(2).split(",") if x.strip() != ""]
+                result["BatcelList"] = [cells0, cells1]
             except Exception:
-                _LOGGER.debug("Failed to parse BatcelList from %r", cells_str)
+                _LOGGER.debug("Failed to parse BatcelList from %r", m.group(0))
+        else:
+            # Fallback: only the first sub-array present/parseable.
+            m = re.search(r'"BatcelList"\s*:\s*\[\s*\[([0-9,\s-]+)\]', norm)
+            if m:
+                cells_str = m.group(1)
+                try:
+                    cells0 = [int(x) for x in cells_str.split(",") if x.strip() != ""]
+                    result["BatcelList"] = [cells0]
+                except Exception:
+                    _LOGGER.debug("Failed to parse BatcelList from %r", cells_str)
 
         _LOGGER.debug("Parsed Felicity real data dict: %s", result)
 

--- a/custom_components/felicity_battery/binary_sensor.py
+++ b/custom_components/felicity_battery/binary_sensor.py
@@ -17,9 +17,25 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .sensor import _fallback_model
+
+DEFAULT_MODEL = "Felicity Battery (local API)"
 
 # Порог "большого" разброса по ячейкам, В
 CELL_DRIFT_HIGH_THRESHOLD_V = 0.03
+
+
+def _estate_mode(code) -> int | None:
+    """Decode charge/discharge/standby mode out of 'Estate'.
+
+    See the matching helper + comment in sensor.py for how this was
+    derived: Estate = <device-specific base bits> + mode*0x1000, mode
+    0=standby, 1=discharging, 2=charging - confirmed across two
+    different physical units with different base bits (0x0C0, 0x3C0).
+    """
+    if not isinstance(code, int):
+        return None
+    return (code >> 12) & 0xF
 
 
 @dataclass
@@ -30,13 +46,13 @@ class FelicityBinarySensorDescription(BinarySensorEntityDescription):
 BINARY_SENSOR_DESCRIPTIONS: tuple[FelicityBinarySensorDescription, ...] = (
     FelicityBinarySensorDescription(
         key="fault_active",
-        name="Battery Fault Active",
+        name="Battery Fault",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicityBinarySensorDescription(
         key="warning_active",
-        name="Battery Warning Active",
+        name="Battery Warning",
         device_class=BinarySensorDeviceClass.PROBLEM,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
@@ -105,17 +121,16 @@ class FelicityBinarySensor(CoordinatorEntity, BinarySensorEntity):
         sw_version = basic.get("version")
         host = self._entry.data.get(CONF_HOST)
         serial_display = f"{serial} ({host})" if host else serial
-
+        model = self._entry.data.get("model") or DEFAULT_MODEL
 
         return {
             "identifiers": {(DOMAIN, serial)},
             "name": self._entry.data.get("name", "Felicity Battery"),
             "manufacturer": "Felicity",
-            "model": "FLA48200",
+            "model": model,
             "sw_version": sw_version,
             "serial_number": serial_display,
         }
-
 
     @property
     def is_on(self) -> bool | None:
@@ -145,9 +160,10 @@ class FelicityBinarySensor(CoordinatorEntity, BinarySensorEntity):
             return v != 0
 
         estate = data.get("Estate")
+        mode = _estate_mode(estate)
         if key == "charging":
             # по коду состояния + по знаку тока
-            if estate == 9152:
+            if mode == 2 or estate == 9152:
                 return True
             i_raw = get_nested(("Batt", 1, 0))
             if i_raw is None:
@@ -155,7 +171,7 @@ class FelicityBinarySensor(CoordinatorEntity, BinarySensorEntity):
             return (i_raw / 10.0) > 0.05
 
         if key == "discharging":
-            if estate == 5056:
+            if mode == 1 or estate == 5056:
                 return True
             i_raw = get_nested(("Batt", 1, 0))
             if i_raw is None:
@@ -163,7 +179,7 @@ class FelicityBinarySensor(CoordinatorEntity, BinarySensorEntity):
             return (i_raw / 10.0) < -0.05
 
         if key == "standby":
-            if estate in (960, 320):
+            if mode == 0 or estate == 320:
                 return True
             i_raw = get_nested(("Batt", 1, 0))
             if i_raw is None:

--- a/custom_components/felicity_battery/binary_sensor.py
+++ b/custom_components/felicity_battery/binary_sensor.py
@@ -17,11 +17,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .sensor import _fallback_model
+from .sensor import _bcu_version, _fallback_model
 
-DEFAULT_MODEL = "Felicity Battery (local API)"
-
-# Порог "большого" разброса по ячейкам, В
+# Threshold for a "large" cell voltage spread, in volts
 CELL_DRIFT_HIGH_THRESHOLD_V = 0.03
 
 
@@ -118,10 +116,13 @@ class FelicityBinarySensor(CoordinatorEntity, BinarySensorEntity):
         data = self.coordinator.data or {}
         serial = data.get("DevSN") or data.get("wifiSN") or self._entry.entry_id
         basic = data.get("_basic") or {}
-        sw_version = basic.get("version")
+        # Same logic as sensor.py's device_info - BCU version in the
+        # "Firmware" field, WiFi module FW as a fallback (also still
+        # available separately as its own sensor).
+        sw_version = _bcu_version(basic) or basic.get("version")
         host = self._entry.data.get(CONF_HOST)
         serial_display = f"{serial} ({host})" if host else serial
-        model = self._entry.data.get("model") or DEFAULT_MODEL
+        model = self._entry.data.get("model") or _fallback_model(basic)
 
         return {
             "identifiers": {(DOMAIN, serial)},
@@ -162,7 +163,7 @@ class FelicityBinarySensor(CoordinatorEntity, BinarySensorEntity):
         estate = data.get("Estate")
         mode = _estate_mode(estate)
         if key == "charging":
-            # по коду состояния + по знаку тока
+            # by state code + by current sign
             if mode == 2 or estate == 9152:
                 return True
             i_raw = get_nested(("Batt", 1, 0))

--- a/custom_components/felicity_battery/config_flow.py
+++ b/custom_components/felicity_battery/config_flow.py
@@ -16,6 +16,8 @@ from .const import (
 )
 _LOGGER = logging.getLogger(__name__)
 
+CONF_MODEL = "model"
+
 
 class FelicityConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Felicity Battery local device."""
@@ -46,7 +48,14 @@ class FelicityConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_NAME: user_input[CONF_NAME],
                     CONF_HOST: host,
                     CONF_PORT: port,
-},
+                    # The device's own local API never reports a
+                    # human-readable model string (only numeric Type/
+                    # SubType codes), so we can't detect e.g. "FLA48200"
+                    # or "LUX-X-96050HG01" automatically. Let the user
+                    # type theirs in; empty is fine, we fall back to a
+                    # generic label in device_info.
+                    CONF_MODEL: user_input.get(CONF_MODEL, "").strip(),
+                },
             )
 
         data_schema = vol.Schema(
@@ -54,6 +63,7 @@ class FelicityConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_NAME, default="Felicity"): str,
                 vol.Required(CONF_HOST): str,
                 vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+                vol.Optional(CONF_MODEL, default=""): str,
             }
         )
 
@@ -61,4 +71,11 @@ class FelicityConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=data_schema,
             errors=errors,
+            description_placeholders={
+                "model_hint": (
+                    "Optional: the model printed on your battery/label "
+                    "(e.g. LUX-X-96050HG01). The device itself doesn't "
+                    "report this, so it's only used for display."
+                )
+            },
         )

--- a/custom_components/felicity_battery/config_flow.py
+++ b/custom_components/felicity_battery/config_flow.py
@@ -34,7 +34,7 @@ class FelicityConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             host = user_input[CONF_HOST]
             port = user_input[CONF_PORT]
 
-            # Не допускаем дубликаты для одного и того же host:port
+            # Don't allow duplicates for the same host:port
             for existing in self._async_current_entries():
                 if existing.data.get(CONF_HOST) == host and existing.data.get(CONF_PORT) == port:
                     return self.async_abort(reason="already_configured")

--- a/custom_components/felicity_battery/manifest.json
+++ b/custom_components/felicity_battery/manifest.json
@@ -1,8 +1,8 @@
 {
   "domain": "felicity_battery",
   "name": "Felicity Battery",
-  "description": "Home Assistant custom integration for Felicity FLA48200 batteries via local TCP API (port 53970).",
-  "version": "0.1.0",
+  "description": "Home Assistant custom integration for Felicity batteries via the local TCP API exposed by their Wi-Fi module (port 53970). Tested with FLA48200 and LUX-X-96050HG01.",
+  "version": "0.2.0",
   "documentation": "https://github.com/vitalik33-tir/ha-felicity-battery",
   "requirements": [],
   "codeowners": [

--- a/custom_components/felicity_battery/sensor.py
+++ b/custom_components/felicity_battery/sensor.py
@@ -40,6 +40,29 @@ def _fallback_model(basic: dict[str, Any]) -> str:
     return DEFAULT_MODEL
 
 
+def _bcu_version(basic: dict[str, Any]) -> str | None:
+    """Format the BCU (Battery Control Unit) version - M1SwVer + DSwVer,
+    e.g. "203-05-86". Confirmed exact match against the FSOLAR app's own
+    "Versionsdaten" screen.
+
+    Used both for the "Battery BCU Version" sensor and as the device
+    page's "Firmware" field: of the four version numbers this battery
+    reports (BCU/SCU/BMU/LCD), BCU is the one Felicity's own app lists
+    first, and "Control Unit" is the master pack-level controller (the
+    one deciding charge/discharge behaviour, reporting Estate/workM,
+    etc.) - the most reasonable single value to represent "the battery's
+    firmware version" if only one can be shown. The Wi-Fi module's own
+    firmware (previously shown here) stays available separately as the
+    "WiFi Module FW Version" sensor.
+    """
+    major = basic.get("M1SwVer")
+    minor = basic.get("DSwVer")
+    if not isinstance(major, (int, float)) or not isinstance(minor, (int, float)):
+        return None
+    minor = int(minor)
+    return f"{int(major)}-{minor // 100:02d}-{minor % 100:02d}"
+
+
 def _estate_mode(code: Any) -> int | None:
     """Decode the charge/discharge/standby mode out of the 'Estate' field.
 
@@ -70,6 +93,7 @@ class FelicitySensorDescription(SensorEntityDescription):
 
 
 SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
+    # --- Main operational sensors ---
     FelicitySensorDescription(
         key="soc",
         name="Battery SOC",
@@ -105,6 +129,7 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash",
     ),
+    # Split charge/discharge current and power
     FelicitySensorDescription(
         key="charge_current",
         name="Battery Charge Current",
@@ -145,6 +170,11 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         icon="mdi:swap-vertical",
     ),
     FelicitySensorDescription(
+        # NOT two independent temperature probes - confirmed against the
+        # FSOLAR app ("Max. Temp. der Zelle: 28°C" / "Min. Temp. der
+        # Zelle: 22°C"): this is the max/min across the pack's cell
+        # temperature sensors, analogous to Max/Min Cell Voltage below.
+        # Key kept as temp1 for entity continuity.
         key="temp1",
         name="Max Cell Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
@@ -164,9 +194,13 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         suggested_display_precision=1,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+
+    # --- Additional battery telemetry (state of health, capacity,
+    # voltage limits, working mode) - values confirmed by comparing the
+    # raw readings against the FSOLAR app's own displayed numbers ---
     FelicitySensorDescription(
-        # Batsoc[0][1] = "battSoh" per Felicity's own protocol, /10.
-        # Matches the Cloud UI's reported 97% exactly.
+        # Batsoc[0][1], scale /10. Matches the Cloud UI's reported 97%
+        # exactly.
         key="soh",
         name="Battery SOH",
         native_unit_of_measurement=PERCENTAGE,
@@ -175,6 +209,8 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         suggested_display_precision=1,
     ),
     FelicitySensorDescription(
+        # Batsoc[0][2], scale /1000. Matches the FSOLAR app's displayed
+        # battery capacity (Ah) exactly.
         key="capacity_ah",
         name="Battery Capacity",
         native_unit_of_measurement="Ah",
@@ -184,6 +220,8 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
+        # LVolCur[0][0], scale /10. Exact match to the charge voltage
+        # limit shown in the FSOLAR app.
         key="charge_voltage_limit",
         name="Charge Voltage Limit",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -194,6 +232,8 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
+        # LVolCur[0][1], scale /10. Exact match to the discharge voltage
+        # limit shown in the FSOLAR app.
         key="discharge_voltage_limit",
         name="Discharge Voltage Limit",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -204,10 +244,16 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
+        # workM, decoded using the mode table below (0=Power On,
+        # 1=Standby, 2=Battery Mode, 3=Discharge only, 4=Charge only,
+        # 5=Low power, 6=Fault, 7=Shutdown, 8=Test, 9=Upgrade), confirmed
+        # against observed values and the FSOLAR app's own state display.
         key="working_mode",
         name="Working Mode",
         icon="mdi:state-machine",
     ),
+
+    # --- Cell-level diagnostics ---
     FelicitySensorDescription(
         key="max_cell_v",
         name="Max Cell Voltage",
@@ -238,6 +284,11 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         suggested_display_precision=3,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+
+    # --- Pack/string voltages (BatcelList[0]) - keys unchanged
+    # (cell_N_v) for entity continuity, but renamed: these aren't
+    # individual cells, they're 12 sub-pack/string voltages (~53V), see
+    # BatcelList[1] further below for the real per-cell voltages. ---
     FelicitySensorDescription(
         key="cell_1_v", name="Pack 1 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -334,6 +385,11 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
+
+    # --- Real individual cell voltages 1-16 (BatcelList[1], previously
+    # never parsed/exposed at all) - confirmed against the FSOLAR app's
+    # displayed max/min cell voltage. New keys, since this is a
+    # different physical quantity than the pack voltages above. ---
     FelicitySensorDescription(
         key="cell_real_1_v", name="Cell 1 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -430,6 +486,8 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
     ),
+
+    # --- Limits from runtime data ---
     FelicitySensorDescription(
         key="max_charge_current",
         name="Max Charge Current (runtime)",
@@ -462,12 +520,24 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         icon="mdi:alert-circle",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+
+    # --- Info / firmware / type / serials ---
     FelicitySensorDescription(
+        # NOTE: this is the Wi-Fi module's own firmware (basic["version"]),
+        # NOT a battery board version - the FSOLAR app shows it separately
+        # from BCU/SCU/BMU/LCD (see below), which are the actual battery
+        # firmware versions. Renamed to avoid the misleading "Battery FW"
+        # label; key kept as fw_version for entity continuity.
         key="fw_version",
         name="WiFi Module FW Version",
         icon="mdi:chip",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # NOTE: standalone "Battery BMS M1/M2 FW" sensors (raw M1SwVer/M2SwVer)
+    # were removed - they were an exact subset of BCU/SCU below (e.g.
+    # M1SwVer is literally the first component of BCU: "203-05-86"),
+    # so they added no information, just clutter. bms_m1_fw/bms_m2_fw keys
+    # are intentionally no longer used anywhere.
     FelicitySensorDescription(
         # Confirmed against the FSOLAR app's "Versionsdaten" screen:
         # BCU = M1SwVer + DSwVer (formatted "0X-YY"), e.g. 203-05-86.
@@ -498,6 +568,7 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
+        # From 'wifilocalMonitor:get Date' (not previously queried at all).
         key="wifi_rssi",
         name="WiFi Module Signal",
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
@@ -529,6 +600,8 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         icon="mdi:wifi",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+
+    # --- Settings / thresholds (dev set infor) ---
     FelicitySensorDescription(
         key="ttl_pack",
         name="Battery Pack Count",
@@ -660,7 +733,12 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
         data = self.coordinator.data or {}
         serial = data.get("DevSN") or data.get("wifiSN") or self._entry.entry_id
         basic = data.get("_basic") or {}
-        sw_version = basic.get("version")
+        # Show the BCU (Battery Control Unit) version here - see
+        # _bcu_version() for why that one was picked among the battery's
+        # four version numbers. Falls back to the Wi-Fi module's own
+        # firmware if BCU data isn't available (e.g. a different device/
+        # firmware that doesn't expose M1SwVer/DSwVer under those names).
+        sw_version = _bcu_version(basic) or basic.get("version")
         host = self._entry.data.get(CONF_HOST)
         serial_display = f"{serial} ({host})" if host else serial
         model = self._entry.data.get("model") or _fallback_model(basic)
@@ -831,25 +909,26 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
         # --- Pack/string OR real cell voltages (BatcelList) - ADAPTIVE,
         # see also the `name` property override below.
         #
-        # Backward-compat note: the raw magnitude/
-        # meaning of BatcelList row 0 is NOT the same across all Felicity
-        # battery models:
-        #   - protocol Type 119 (this integration's LUX-X-96050HG01/
-        #     BCU600050-family test unit): row 0 field is named "cellVolt*"
-        #     but with magnification -2 (i.e. /100), and the device's real
-        #     per-cell data lives in a SECOND array.
-        #     -> two arrays present at runtime.
-        #   - protocol Type 48/112: row 0 is
-        #     named "cellVolt*" with magnification -3 (i.e. /1000) and
-        #     there is no second array at all - row 0 already *is* the
-        #     real per-cell voltage.
-        #     -> only one array present at runtime.
+        # Backward-compat note: the meaning of BatcelList row 0 is NOT the
+        # same on every Felicity battery model. On this integration's own
+        # test unit (a multi-module pack), row 0 turned out to be
+        # pack/string-level voltages (~53V each, /100 scale) rather than
+        # individual cells, with the real per-cell data only showing up in
+        # a second array (row 1, /1000 scale) - confirmed against the
+        # FSOLAR app's own max/min cell voltage display. The original,
+        # unpatched integration (written for a different, presumably
+        # single-module battery) only ever saw one array and treated row 0
+        # directly as real per-cell voltage (/1000) - which is exactly
+        # right for that kind of device, just wrong for a multi-module one
+        # like this integration's test unit.
         #
-        # So instead of hardcoding one interpretation, we branch on how
-        # many BatcelList arrays the device actually sends:
+        # Rather than hardcoding one interpretation and risking silently
+        # wrong values on whichever device shape wasn't tested, this code
+        # branches on how many BatcelList arrays the device actually sends
+        # at runtime:
         #   - 1 array  -> "cell_N_v" behaves exactly like the original,
-        #     unpatched integration (row 0, /1000, "Cell N Voltage") so a
-        #     FLA48200-style upgrade is a complete no-op for these
+        #     unpatched integration (row 0, /1000, "Cell N Voltage"), so a
+        #     single-module-style upgrade is a complete no-op for these
         #     entities: same key, same scale, same name, same history.
         #     "cell_real_N_v" stays unpopulated (filtered out at setup).
         #   - 2+ arrays -> "cell_N_v" becomes "Pack N Voltage" (/100, row
@@ -919,15 +998,16 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
         if key == "fw_version":
             return basic.get("version")
 
-        if key in ("bcu_version", "scu_version", "bmu_version"):
+        if key == "bcu_version":
+            return _bcu_version(basic)
+
+        if key in ("scu_version", "bmu_version"):
             def _fmt(major: Any, minor: Any) -> str | None:
                 if not isinstance(major, (int, float)) or not isinstance(minor, (int, float)):
                     return None
                 minor = int(minor)
                 return f"{int(major)}-{minor // 100:02d}-{minor % 100:02d}"
 
-            if key == "bcu_version":
-                return _fmt(basic.get("M1SwVer"), basic.get("DSwVer"))
             if key == "scu_version":
                 return _fmt(basic.get("M2SwVer"), basic.get("CtHwVer"))
             if key == "bmu_version":
@@ -959,8 +1039,9 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
             # The device's own 'ttlPack' field (in _settings) is transport
             # metadata (how many concatenated JSON objects make up the
             # "get dev set infor" reply), NOT the physical pack count.
-            # BMSpara[0][0] is officially named "cellNumber" - use that
-            # directly now. Falls back to counting populated BatcelList[0]
+            # BMSpara[0][0] reports the actual pack/module count directly
+            # and matches this device's real module count exactly - use
+            # that instead. Falls back to counting populated BatcelList[0]
             # slots (which independently gives the same number) if
             # BMSpara is ever missing.
             official = get_nested(("BMSpara", 0, 0))
@@ -1006,7 +1087,7 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
         data: dict = self.coordinator.data or {}
         key = self.entity_description.key
 
-        # Агрегация по ячейкам для сенсора cell_drift
+        # Per-cell aggregation for the cell_drift sensor
         # NOTE: uses BatcelList[1] (the real per-cell array, ~3.3V each,
         # confirmed against the FSOLAR app) - it previously read
         # BatcelList[0], which is actually the pack/string voltages

--- a/custom_components/felicity_battery/sensor.py
+++ b/custom_components/felicity_battery/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfPower,
@@ -26,6 +27,42 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 
+DEFAULT_MODEL = "Felicity Battery (local API)"
+
+
+def _fallback_model(basic: dict[str, Any]) -> str:
+    """Best-effort model label when the user hasn't set one manually.
+    """
+    type_code = basic.get("Type")
+    subtype_code = basic.get("SubType")
+    if type_code is not None and subtype_code is not None:
+        return f"Felicity Battery (Type {type_code}/{subtype_code})"
+    return DEFAULT_MODEL
+
+
+def _estate_mode(code: Any) -> int | None:
+    """Decode the charge/discharge/standby mode out of the 'Estate' field.
+
+    Confirmed across two different physical units (a FLA48200-style pack
+    the integration originally assumed, and a LUX-X-96050HG01 observed
+    live): Estate = <device-specific base flags, low 12 bits> +
+    mode * 0x1000. The base bits differ per device/firmware batch
+    (0x0C0 vs 0x3C0 observed so far), but the mode nibble is consistent:
+      0 = standby, 1 = discharging, 2 = charging.
+
+    This is unconfirmed/reverse-engineered - Estate/workState has no
+    decode table anywhere in Felicity's own app, not even for exact
+    values like "full" (the one sample seen, 320, decodes as mode 0,
+    same as standby). For that reason there's no dedicated sensor
+    exposing this value directly; it's only used as a secondary
+    fallback (behind the real current reading) in "direction" and the
+    charging/discharging/standby binary sensors, never as the sole
+    source of truth and never surfaced as a raw/guessed value.
+    """
+    if not isinstance(code, int):
+        return None
+    return (code >> 12) & 0xF
+
 
 @dataclass
 class FelicitySensorDescription(SensorEntityDescription):
@@ -33,7 +70,6 @@ class FelicitySensorDescription(SensorEntityDescription):
 
 
 SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
-    # --- Основные рабочие сенсоры ---
     FelicitySensorDescription(
         key="soc",
         name="Battery SOC",
@@ -69,7 +105,6 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         icon="mdi:flash",
     ),
-    # Разделённые токи/мощности
     FelicitySensorDescription(
         key="charge_current",
         name="Battery Charge Current",
@@ -111,24 +146,68 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
     ),
     FelicitySensorDescription(
         key="temp1",
-        name="Battery Temp 1",
+        name="Max Cell Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:thermometer",
+        icon="mdi:thermometer-high",
         suggested_display_precision=1,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
         key="temp2",
-        name="Battery Temp 2",
+        name="Min Cell Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:thermometer",
+        icon="mdi:thermometer-low",
+        suggested_display_precision=1,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        # Batsoc[0][1] = "battSoh" per Felicity's own protocol, /10.
+        # Matches the Cloud UI's reported 97% exactly.
+        key="soh",
+        name="Battery SOH",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:heart-pulse",
         suggested_display_precision=1,
     ),
-
-    # --- Диагностика по ячейкам ---
+    FelicitySensorDescription(
+        key="capacity_ah",
+        name="Battery Capacity",
+        native_unit_of_measurement="Ah",
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery-charging-100",
+        suggested_display_precision=1,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="charge_voltage_limit",
+        name="Charge Voltage Limit",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:flash",
+        suggested_display_precision=1,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="discharge_voltage_limit",
+        name="Discharge Voltage Limit",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:flash",
+        suggested_display_precision=1,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="working_mode",
+        name="Working Mode",
+        icon="mdi:state-machine",
+    ),
     FelicitySensorDescription(
         key="max_cell_v",
         name="Max Cell Voltage",
@@ -159,170 +238,198 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         suggested_display_precision=3,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-
-    # --- Напряжения ячеек 1–16 (диагностика) ---
     FelicitySensorDescription(
-        key="cell_1_v",
-        name="Cell 1 Voltage",
+        key="cell_1_v", name="Pack 1 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_2_v",
-        name="Cell 2 Voltage",
+        key="cell_2_v", name="Pack 2 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_3_v",
-        name="Cell 3 Voltage",
+        key="cell_3_v", name="Pack 3 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_4_v",
-        name="Cell 4 Voltage",
+        key="cell_4_v", name="Pack 4 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_5_v",
-        name="Cell 5 Voltage",
+        key="cell_5_v", name="Pack 5 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_6_v",
-        name="Cell 6 Voltage",
+        key="cell_6_v", name="Pack 6 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_7_v",
-        name="Cell 7 Voltage",
+        key="cell_7_v", name="Pack 7 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_8_v",
-        name="Cell 8 Voltage",
+        key="cell_8_v", name="Pack 8 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_9_v",
-        name="Cell 9 Voltage",
+        key="cell_9_v", name="Pack 9 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_10_v",
-        name="Cell 10 Voltage",
+        key="cell_10_v", name="Pack 10 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_11_v",
-        name="Cell 11 Voltage",
+        key="cell_11_v", name="Pack 11 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_12_v",
-        name="Cell 12 Voltage",
+        key="cell_12_v", name="Pack 12 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_13_v",
-        name="Cell 13 Voltage",
+        key="cell_13_v", name="Pack 13 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_14_v",
-        name="Cell 14 Voltage",
+        key="cell_14_v", name="Pack 14 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_15_v",
-        name="Cell 15 Voltage",
+        key="cell_15_v", name="Pack 15 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="cell_16_v",
-        name="Cell 16 Voltage",
+        key="cell_16_v", name="Pack 16 Voltage",
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        icon="mdi:battery",
-        suggested_display_precision=3,
-        entity_category=EntityCategory.DIAGNOSTIC,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=2, entity_category=EntityCategory.DIAGNOSTIC,
     ),
-
-    # --- Лимиты по фактическим данным ---
+    FelicitySensorDescription(
+        key="cell_real_1_v", name="Cell 1 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_2_v", name="Cell 2 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_3_v", name="Cell 3 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_4_v", name="Cell 4 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_5_v", name="Cell 5 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_6_v", name="Cell 6 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_7_v", name="Cell 7 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_8_v", name="Cell 8 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_9_v", name="Cell 9 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_10_v", name="Cell 10 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_11_v", name="Cell 11 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_12_v", name="Cell 12 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_13_v", name="Cell 13 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_14_v", name="Cell 14 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_15_v", name="Cell 15 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="cell_real_16_v", name="Cell 16 Voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:battery", suggested_display_precision=3, entity_category=EntityCategory.DIAGNOSTIC,
+    ),
     FelicitySensorDescription(
         key="max_charge_current",
         name="Max Charge Current (runtime)",
@@ -343,13 +450,6 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         suggested_display_precision=1,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-
-    # --- Состояние / коды ---
-    FelicitySensorDescription(
-        key="state",
-        name="Battery State",
-        icon="mdi:battery-heart",
-    ),
     FelicitySensorDescription(
         key="fault",
         name="Battery Fault Code",
@@ -362,24 +462,47 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         icon="mdi:alert-circle",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-
-    # --- Инфо / прошивки / тип / серийники ---
     FelicitySensorDescription(
         key="fw_version",
-        name="Battery FW Version",
+        name="WiFi Module FW Version",
         icon="mdi:chip",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="bms_m1_fw",
-        name="Battery BMS M1 FW",
+        # Confirmed against the FSOLAR app's "Versionsdaten" screen:
+        # BCU = M1SwVer + DSwVer (formatted "0X-YY"), e.g. 203-05-86.
+        key="bcu_version",
+        name="Battery BCU Version",
         icon="mdi:chip",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
-        key="bms_m2_fw",
-        name="Battery BMS M2 FW",
+        # SCU = M2SwVer + CtHwVer (formatted "0X-YY"), e.g. 203-03-00.
+        key="scu_version",
+        name="Battery SCU Version",
         icon="mdi:chip",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        # BMU = DHwVer + PwHwVer (formatted "0X-YY"), e.g. 202-03-00.
+        key="bmu_version",
+        name="Battery BMU Version",
+        icon="mdi:chip",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        # LCD = BDsVer as-is, e.g. 118.
+        key="lcd_version",
+        name="Battery LCD Version",
+        icon="mdi:chip",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    FelicitySensorDescription(
+        key="wifi_rssi",
+        name="WiFi Module Signal",
+        device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
@@ -406,12 +529,10 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
         icon="mdi:wifi",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-
-    # --- Настройки / пороги (dev set infor) ---
     FelicitySensorDescription(
         key="ttl_pack",
         name="Battery Pack Count",
-        icon="mdi:battery-variant",
+        icon="mdi:counter",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     FelicitySensorDescription(
@@ -456,7 +577,7 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
     ),
     FelicitySensorDescription(
         key="charge_limit_setting",
-        name="Charge Current Limit (setting)",
+        name="Charge Current Limit (BMS protection)",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -466,7 +587,7 @@ SENSOR_DESCRIPTIONS: tuple[FelicitySensorDescription, ...] = (
     ),
     FelicitySensorDescription(
         key="discharge_limit_setting",
-        name="Discharge Current Limit (setting)",
+        name="Discharge Current Limit (BMS protection)",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
@@ -482,13 +603,38 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up Felicity sensors based on a config entry."""
+    """Set up Felicity sensors based on a config entry.
+
+    Only add sensors that actually produced a value on the first refresh.
+    Some SENSOR_DESCRIPTIONS map to fields that don't exist (or are named
+    differently) on every Felicity battery model/firmware; leaving those
+    entities permanently stuck on 'unknown' is just noise, so we skip them
+    instead. (coordinator.async_config_entry_first_refresh() has already
+    run in __init__.py by the time this is called, so coordinator.data is
+    populated.)
+    """
     data = hass.data[DOMAIN][entry.entry_id]
     coordinator = data["coordinator"]
 
-    entities: list[FelicitySensor] = [
-        FelicitySensor(coordinator, entry, desc) for desc in SENSOR_DESCRIPTIONS
-    ]
+    entities: list[FelicitySensor] = []
+    skipped: list[str] = []
+    for desc in SENSOR_DESCRIPTIONS:
+        entity = FelicitySensor(coordinator, entry, desc)
+        if entity.native_value is not None:
+            entities.append(entity)
+        else:
+            skipped.append(desc.key)
+
+    if skipped:
+        # Not an error - just informational, in case a future firmware
+        # update starts reporting one of these fields.
+        import logging
+
+        logging.getLogger(__name__).info(
+            "Felicity Battery: skipping sensors with no data on this device: %s",
+            ", ".join(skipped),
+        )
+
     async_add_entities(entities)
 
 
@@ -517,18 +663,34 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
         sw_version = basic.get("version")
         host = self._entry.data.get(CONF_HOST)
         serial_display = f"{serial} ({host})" if host else serial
-
+        model = self._entry.data.get("model") or _fallback_model(basic)
 
         return {
             "identifiers": {(DOMAIN, serial)},
             "name": self._entry.data.get("name", "Felicity Battery"),
             "manufacturer": "Felicity",
-            "model": "FLA48200",
+            "model": model,
             "sw_version": sw_version,
             "serial_number": serial_display,
         }
 
-
+    @property
+    def name(self) -> str | None:
+        """Dynamic display name for entities whose meaning depends on
+        runtime data - see the long comment in native_value() for
+        cell_*_v. Everything else falls back to the static description
+        name as usual."""
+        key = self.entity_description.key
+        if key.startswith("cell_") and key.endswith("_v") and not key.startswith("cell_real_"):
+            try:
+                n = int(key.split("_")[1])
+            except (ValueError, IndexError):
+                n = "?"
+            cells_list = (self.coordinator.data or {}).get("BatcelList")
+            if isinstance(cells_list, list) and len(cells_list) >= 2:
+                return f"Pack {n} Voltage"
+            return f"Cell {n} Voltage"
+        return self.entity_description.name
 
     @property
     def native_value(self) -> Any:
@@ -609,13 +771,11 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
                     return "charging"
                 if current < -0.05:
                     return "discharging"
-            code = data.get("Estate")
-            if code == 9152:
+            mode = _estate_mode(data.get("Estate"))
+            if mode == 2:
                 return "charging"
-            if code == 5056:
+            if mode == 1:
                 return "discharging"
-            if code in (960, 320):
-                return "idle"
             return "idle"
 
         if key == "temp1":
@@ -625,6 +785,33 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
         if key == "temp2":
             raw = get_nested(("BTemp", 0, 1))
             return round(raw / 10, 1) if raw is not None else None
+
+        if key == "soh":
+            raw = get_nested(("Batsoc", 0, 1))
+            return round(raw / 10, 1) if raw is not None else None
+
+        if key == "capacity_ah":
+            raw = get_nested(("Batsoc", 0, 2))
+            return round(raw / 1000, 1) if raw is not None else None
+
+        if key == "charge_voltage_limit":
+            raw = get_nested(("LVolCur", 0, 0))
+            return round(raw / 10, 1) if raw is not None else None
+
+        if key == "discharge_voltage_limit":
+            raw = get_nested(("LVolCur", 0, 1))
+            return round(raw / 10, 1) if raw is not None else None
+
+        if key == "working_mode":
+            code = data.get("workM")
+            modes = {
+                0: "power_on", 1: "standby", 2: "battery_mode",
+                3: "discharge_only", 4: "charge_only", 5: "low_power",
+                6: "fault", 7: "shutdown", 8: "test", 9: "upgrade",
+            }
+            if code is None:
+                return None
+            return modes.get(code, f"unknown({code})")
 
         if key == "max_cell_v":
             raw = get_nested(("BMaxMin", 0, 0))
@@ -641,16 +828,67 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
                 return None
             return round((max_raw - min_raw) / 1000, 3)
 
-        # --- Cell voltages 1–16 ---
-        if key.startswith("cell_") and key.endswith("_v"):
+        # --- Pack/string OR real cell voltages (BatcelList) - ADAPTIVE,
+        # see also the `name` property override below.
+        #
+        # Backward-compat note: the raw magnitude/
+        # meaning of BatcelList row 0 is NOT the same across all Felicity
+        # battery models:
+        #   - protocol Type 119 (this integration's LUX-X-96050HG01/
+        #     BCU600050-family test unit): row 0 field is named "cellVolt*"
+        #     but with magnification -2 (i.e. /100), and the device's real
+        #     per-cell data lives in a SECOND array.
+        #     -> two arrays present at runtime.
+        #   - protocol Type 48/112: row 0 is
+        #     named "cellVolt*" with magnification -3 (i.e. /1000) and
+        #     there is no second array at all - row 0 already *is* the
+        #     real per-cell voltage.
+        #     -> only one array present at runtime.
+        #
+        # So instead of hardcoding one interpretation, we branch on how
+        # many BatcelList arrays the device actually sends:
+        #   - 1 array  -> "cell_N_v" behaves exactly like the original,
+        #     unpatched integration (row 0, /1000, "Cell N Voltage") so a
+        #     FLA48200-style upgrade is a complete no-op for these
+        #     entities: same key, same scale, same name, same history.
+        #     "cell_real_N_v" stays unpopulated (filtered out at setup).
+        #   - 2+ arrays -> "cell_N_v" becomes "Pack N Voltage" (/100, row
+        #     0) as on this integration's own test unit, and the new
+        #     "cell_real_N_v" entities (row 1, /1000) provide the true
+        #     per-cell readings.
+        if key.startswith("cell_") and key.endswith("_v") and not key.startswith("cell_real_"):
+            cells_list = get_nested(("BatcelList",))
+            if not isinstance(cells_list, list) or not cells_list:
+                return None
             try:
                 idx = int(key.split("_")[1]) - 1  # 0..15
             except (ValueError, IndexError):
                 return None
             raw = get_nested(("BatcelList", 0, idx))
-            if raw is None or raw == 65535:
+            # 65535 is this device's explicit "no reading" sentinel; 0 is
+            # what unpopulated slots come back as - treat both as "not
+            # present" so the setup filter drops these entities instead of
+            # pinning them at a permanent, misleading 0 V.
+            if raw is None or raw in (0, 65535):
                 return None
-            # мВ -> В, три знака
+            if len(cells_list) >= 2:
+                return round(raw / 100.0, 2)
+            return round(raw / 1000.0, 3)
+
+        if key.startswith("cell_real_") and key.endswith("_v"):
+            cells_list = get_nested(("BatcelList",))
+            # Only meaningful on multi-array devices - see above. On a
+            # single-array device this stays unpopulated on purpose so it
+            # doesn't show up as a confusing duplicate of cell_N_v.
+            if not isinstance(cells_list, list) or len(cells_list) < 2:
+                return None
+            try:
+                idx = int(key.split("_")[2]) - 1  # 0..15
+            except (ValueError, IndexError):
+                return None
+            raw = get_nested(("BatcelList", 1, idx))
+            if raw is None or raw in (0, 65535):
+                return None
             return round(raw / 1000.0, 3)
 
         # --- Limits from runtime data ---
@@ -661,20 +899,6 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
         if key == "max_discharge_current":
             raw = get_nested(("LVolCur", 1, 1))
             return round(raw / 10, 1) if raw is not None else None
-
-        if key == "state":
-            code = data.get("Estate")
-            if code is None:
-                return None
-            if code == 320:
-                return "full"
-            if code == 960:
-                return "standby"
-            if code == 9152:
-                return "charging"
-            if code == 5056:
-                return "discharging"
-            return f"unknown({code})"
 
         if key == "fault":
             v = data.get("Bfault")
@@ -695,11 +919,28 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
         if key == "fw_version":
             return basic.get("version")
 
-        if key == "bms_m1_fw":
-            return basic.get("M1SwVer")
+        if key in ("bcu_version", "scu_version", "bmu_version"):
+            def _fmt(major: Any, minor: Any) -> str | None:
+                if not isinstance(major, (int, float)) or not isinstance(minor, (int, float)):
+                    return None
+                minor = int(minor)
+                return f"{int(major)}-{minor // 100:02d}-{minor % 100:02d}"
 
-        if key == "bms_m2_fw":
-            return basic.get("M2SwVer")
+            if key == "bcu_version":
+                return _fmt(basic.get("M1SwVer"), basic.get("DSwVer"))
+            if key == "scu_version":
+                return _fmt(basic.get("M2SwVer"), basic.get("CtHwVer"))
+            if key == "bmu_version":
+                return _fmt(basic.get("DHwVer"), basic.get("PwHwVer"))
+
+        if key == "lcd_version":
+            v = basic.get("BDsVer")
+            return str(v) if v is not None else None
+
+        if key == "wifi_rssi":
+            date_info = data.get("_date") or {}
+            v = date_info.get("rssi")
+            return int(v) if isinstance(v, (int, float)) else None
 
         if key == "battery_type":
             return basic.get("Type")
@@ -715,7 +956,23 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
 
         # --- Settings / thresholds ---
         if key == "ttl_pack":
-            return settings.get("ttlPack")
+            # The device's own 'ttlPack' field (in _settings) is transport
+            # metadata (how many concatenated JSON objects make up the
+            # "get dev set infor" reply), NOT the physical pack count.
+            # BMSpara[0][0] is officially named "cellNumber" - use that
+            # directly now. Falls back to counting populated BatcelList[0]
+            # slots (which independently gives the same number) if
+            # BMSpara is ever missing.
+            official = get_nested(("BMSpara", 0, 0))
+            if isinstance(official, (int, float)) and official > 0:
+                return int(official)
+            cells = get_nested(("BatcelList", 0))
+            if not isinstance(cells, list):
+                return None
+            count = sum(
+                1 for v in cells if isinstance(v, (int, float)) and v not in (0, 65535)
+            )
+            return count or None
 
         if key == "cell_v_80":
             raw = settings.get("wCVP80")
@@ -750,18 +1007,22 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
         key = self.entity_description.key
 
         # Агрегация по ячейкам для сенсора cell_drift
+        # NOTE: uses BatcelList[1] (the real per-cell array, ~3.3V each,
+        # confirmed against the FSOLAR app) - it previously read
+        # BatcelList[0], which is actually the pack/string voltages
+        # (~53V) and produced meaningless "cell" attributes here.
         if key == "cell_drift":
             attrs: dict[str, Any] = {}
             cells_list = data.get("BatcelList")
             if (
                 isinstance(cells_list, list)
-                and cells_list
-                and isinstance(cells_list[0], list)
+                and len(cells_list) > 1
+                and isinstance(cells_list[1], list)
             ):
-                raw_cells = cells_list[0]
+                raw_cells = cells_list[1]
                 cells_v: list[float] = []
                 for c in raw_cells:
-                    if isinstance(c, int) and c != 65535:
+                    if isinstance(c, int) and c not in (0, 65535):
                         cells_v.append(round(c / 1000.0, 3))
                 if cells_v:
                     attrs["cells"] = cells_v
@@ -773,10 +1034,33 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
                     attrs["min_cell_index"] = cells_v.index(min_v) + 1
             return attrs or None
 
+        if key == "ttl_pack":
+            attrs: dict[str, Any] = {}
+            settings = data.get("_settings") or {}
+            if "ttlPack" in settings:
+                attrs["device_reported_ttlPack"] = settings.get("ttlPack")
+                attrs["note"] = (
+                    "device_reported_ttlPack is transport/packet-count "
+                    "metadata from the device's own protocol, not the "
+                    "physical pack/module count. The sensor state above is "
+                    "derived instead from the number of populated entries "
+                    "in BatcelList[0] (realtime payload)."
+                )
+            cells_list = data.get("BatcelList")
+            if (
+                isinstance(cells_list, list)
+                and cells_list
+                and isinstance(cells_list[0], list)
+            ):
+                attrs["batcel_list_0_raw"] = cells_list[0]
+            return attrs or None
+
         if key in {
             "fw_version",
-            "bms_m1_fw",
-            "bms_m2_fw",
+            "bcu_version",
+            "scu_version",
+            "bmu_version",
+            "lcd_version",
             "battery_type",
             "battery_subtype",
             "serial",
@@ -787,14 +1071,32 @@ class FelicitySensor(CoordinatorEntity, SensorEntity):
                 return basic
             return None
 
+        if key == "wifi_rssi":
+            date_info = data.get("_date")
+            if isinstance(date_info, dict):
+                return date_info
+            return None
+
+        if key in {"charge_limit_setting", "discharge_limit_setting"}:
+            attrs: dict[str, Any] = {}
+            settings = data.get("_settings")
+            if isinstance(settings, dict):
+                attrs.update(settings)
+            attrs["note"] = (
+                "This reads the BMS's own protection/cutoff threshold "
+                "(bCCHi2/bDCHi2 in the raw settings) - it's a hardware "
+                "safety ceiling, not necessarily the charge-current limit "
+                "you configure in the FSOLAR app. That app setting is most "
+                "likely enforced on the inverter/charger side and doesn't "
+                "appear to be exposed by this battery-only local API."
+            )
+            return attrs
+
         if key in {
-            "ttl_pack",
             "cell_v_80",
             "cell_v_20",
             "cell_over_voltage",
             "cell_under_voltage",
-            "charge_limit_setting",
-            "discharge_limit_setting",
         }:
             settings = data.get("_settings")
             if isinstance(settings, dict):


### PR DESCRIPTION
- api.py: read-until-idle instead of stop-at-first-"}", add connect/first-byte
  timeouts and a retry wrapper - fixes intermittent "No data received from
  battery" unavailability and truncated multi-fragment "get dev set infor"
  replies. Also poll "get Date" for RSSI.
- Only create sensors that actually return data on first refresh, instead of
  leaving unsupported fields stuck on "unknown".
- Fix Battery Pack Count: was reading transport/fragment-count metadata
  (ttlPack), not the physical pack count. Now uses the official BMSpara
  cellNumber field.
- Fix Pack vs. Cell voltage: BatcelList[0]/[1] were mislabeled and
  incorrectly scaled. Scaling/labeling is now derived at runtime from how
  many arrays the device sends, so single-array devices (e.g. FLA48200)
  keep the original key/scale/name unchanged, while multi-array devices
  get correctly split "Pack N Voltage" / "Cell N Voltage" sensors.
- Fix Battery Temp 1/2: these are pack-wide max/min cell temperature, not
  two independent probes - renamed accordingly.
- Add Battery BCU/SCU/BMU/LCD firmware version sensors (previously only a
  single, misleadingly-named "Battery FW Version" that was actually the
  Wi-Fi module's firmware); remove the now-redundant raw BMS M1/M2 FW
  sensors they superseded.
- Add Battery SOH, Battery Capacity, Charge/Discharge Voltage Limit, and
  Working Mode sensors, based on Felicity's own protocol definitions.
- Remove the "Battery State" sensor: its underlying Estate/workState field
  has no official decode table anywhere in Felicity's own app, so it was
  pure guesswork. Direction/charging/discharging/standby still use the
  same bit pattern, but only as a fallback behind the real current reading.
- Rename "Fault/Warning Active" binary sensors to "Fault"/"Warning" to
  match the PROBLEM device class's built-in on/off wording.
- Add an optional "model" config field, since the device only reports
  numeric Type/SubType codes, not a human-readable model name.